### PR TITLE
Update dev builds to use remote credentials

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -15,7 +15,7 @@
       "distribution": "internal",
       "android": {
         "buildType": "apk",
-        "credentialsSource": "local"
+        "credentialsSource": "remote"
       },
       "ios": {},
       "channel": "development"


### PR DESCRIPTION
## Summary

Fix `eas.json` config to use remote credential source for dev builds.

## Type

- [ ] Feature
- [X] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] CI / DevOps
- [ ] Documentation
- [ ] Dependency update

## Checklist

**General**
- [X] No secrets, credentials, or environment values in diff
- [X] No `console.log` or debug statements left in production code
- [X] No new `^` or `~` semver ranges introduced in `package.json`

**Quality gate** *(skip for documentation-only PRs)*
- [X] `tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm run audit` passes

**Testing**
- [X] Tested locally on iOS
- [X] Tested locally on Android
- [X] Affected auth flow verified (passkey register / login / step-up)

**Native changes** *(if applicable)*
- [ ] Requires native rebuild — reviewer and CI are aware
- [ ] `ios/` and `android/` changes are intentional
- [ ] Podfile.lock updated and committed

**API / contract changes** *(if applicable)*
- [ ] Behaviour verified against the BFF or Auth Server OpenAPI spec
- [ ] Generated types regenerated (`npm run gen:bff-types` / `npm run gen:auth-types`)

**Dependencies** *(if applicable)*
- [ ] `package.json` version bumped
- [ ] Added packages are compatible with installed Expo SDK (`npx expo install --check`)
- [ ] No new vulnerabilities introduced (`npm run audit`)

**Release** *(for `dev` → `staging` PRs)*
- [ ] Version bumped in `package.json`
- [ ] PR labelled correctly (`ota` if applicable)