### PR TITLE
Pin EAS worker toolchain

### DIFF
--- a/.eas/workflows/create-dev-builds.yml
+++ b/.eas/workflows/create-dev-builds.yml
@@ -1,5 +1,10 @@
 name: Create dev builds
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 on:
   push:
     branches: ['dev']

--- a/.eas/workflows/deploy-production-android.yml
+++ b/.eas/workflows/deploy-production-android.yml
@@ -1,5 +1,10 @@
 name: Deploy production (Android)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   build_android:
     name: Build Android

--- a/.eas/workflows/deploy-production-ios.yml
+++ b/.eas/workflows/deploy-production-ios.yml
@@ -1,5 +1,10 @@
 name: Deploy production (iOS)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   build_ios:
     name: Build iOS

--- a/.eas/workflows/deploy-staging-android.yml
+++ b/.eas/workflows/deploy-staging-android.yml
@@ -1,5 +1,10 @@
 name: Deploy staging (Android)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   build_android:
     name: Build Android

--- a/.eas/workflows/deploy-staging-ios.yml
+++ b/.eas/workflows/deploy-staging-ios.yml
@@ -1,5 +1,10 @@
 name: Deploy staging (iOS)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   build_ios:
     name: Build iOS

--- a/.eas/workflows/publish-production-ota-android.yml
+++ b/.eas/workflows/publish-production-ota-android.yml
@@ -1,5 +1,10 @@
 name: Publish production OTA (Android)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   publish_android_update:
     name: Publish Android production OTA update

--- a/.eas/workflows/publish-production-ota-ios.yml
+++ b/.eas/workflows/publish-production-ota-ios.yml
@@ -1,5 +1,10 @@
 name: Publish production OTA (iOS)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   publish_ios_update:
     name: Publish iOS production OTA update

--- a/.eas/workflows/publish-staging-ota-android.yml
+++ b/.eas/workflows/publish-staging-ota-android.yml
@@ -1,5 +1,10 @@
 name: Publish staging OTA (Android)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   publish_android_update:
     name: Publish Android staging OTA update

--- a/.eas/workflows/publish-staging-ota-ios.yml
+++ b/.eas/workflows/publish-staging-ota-ios.yml
@@ -1,5 +1,10 @@
 name: Publish staging OTA (iOS)
 
+defaults:
+  tools:
+    node: "24.18.0"
+    corepack: true
+
 jobs:
   publish_ios_update:
     name: Publish iOS staging OTA update


### PR DESCRIPTION
## Summary

Pin EAS workers to use toolchain consistent with `package.json`

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [X] CI / DevOps
- [ ] Documentation
- [ ] Dependency update

## Checklist

**General**
- [X] No secrets, credentials, or environment values in diff
- [X] No `console.log` or debug statements left in production code
- [X] No new `^` or `~` semver ranges introduced in `package.json`

**Quality gate** *(skip for documentation-only PRs)*
- [X] `tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm run audit` passes

**Testing**
- [ ] Tested locally on iOS
- [ ] Tested locally on Android
- [ ] Affected auth flow verified (passkey register / login / step-up)

**Native changes** *(if applicable)*
- [ ] Requires native rebuild — reviewer and CI are aware
- [ ] `ios/` and `android/` changes are intentional
- [ ] Podfile.lock updated and committed

**API / contract changes** *(if applicable)*
- [ ] Behaviour verified against the BFF or Auth Server OpenAPI spec
- [ ] Generated types regenerated (`npm run gen:bff-types` / `npm run gen:auth-types`)

**Dependencies** *(if applicable)*
- [ ] `package.json` version bumped
- [ ] Added packages are compatible with installed Expo SDK (`npx expo install --check`)
- [X] No new vulnerabilities introduced (`npm run audit`)

**Release** *(for `dev` → `staging` PRs)*
- [ ] Version bumped in `package.json`
- [ ] PR labelled correctly (`ota` if applicable)
