### PR TITLE
CI optimisations

### DIFF
--- a/.github/workflows/route-eas-release.yml
+++ b/.github/workflows/route-eas-release.yml
@@ -10,6 +10,9 @@ on:
       - production
     types:
       - closed
+    paths-ignore:
+      - '.eas/**'
+      - '.github/**'
   workflow_dispatch:
     inputs:
       ref:

--- a/scripts/validate-release-pr.mjs
+++ b/scripts/validate-release-pr.mjs
@@ -46,6 +46,29 @@ if (baseBranch === "dev") {
   process.exit(0);
 }
 
+const changedFiles = execFileSync(
+  "git",
+  ["diff", "--name-only", baseSha, "HEAD"],
+  { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+)
+  .split("\n")
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const ciOnlyPatterns = [".eas/", ".github/"];
+const isCiOnlyChange =
+  changedFiles.length > 0 &&
+  changedFiles.every((file) =>
+    ciOnlyPatterns.some((pattern) => file.startsWith(pattern))
+  );
+
+if (!hasOtaLabel && isCiOnlyChange) {
+  console.log(
+    "PR changes only CI/workflow paths (.eas/, .github/); skipping version and OTA-path checks."
+  );
+  process.exit(0);
+}
+
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
 );
@@ -94,19 +117,6 @@ for (const [label, value] of versionChecks) {
     process.exit(1);
   }
 }
-
-const changedFiles = execFileSync(
-  "git",
-  ["diff", "--name-only", baseSha, "HEAD"],
-  {
-    cwd: repoRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }
-)
-  .split("\n")
-  .map((file) => file.trim())
-  .filter(Boolean);
 
 const hasOnlyOtaSafeChanges = changedFiles.every((file) =>
   otaSafePatterns.some((pattern) =>


### PR DESCRIPTION
## Summary

- Remove the need for full builds and version increments on CI path only changes

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [X] CI / DevOps
- [ ] Documentation
- [ ] Dependency update

## Checklist

**General**
- [X] No secrets, credentials, or environment values in diff
- [X] No `console.log` or debug statements left in production code
- [X] No new `^` or `~` semver ranges introduced in `package.json`

**Quality gate** *(skip for documentation-only PRs)*
- [X] `tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm run audit` passes

**Testing**
- [X] Tested locally on iOS
- [X] Tested locally on Android
- [X] Affected auth flow verified (passkey register / login / step-up)

**Native changes** *(if applicable)*
- [ ] Requires native rebuild — reviewer and CI are aware
- [ ] `ios/` and `android/` changes are intentional
- [ ] Podfile.lock updated and committed

**API / contract changes** *(if applicable)*
- [ ] Behaviour verified against the BFF or Auth Server OpenAPI spec
- [ ] Generated types regenerated (`npm run gen:bff-types` / `npm run gen:auth-types`)

**Dependencies** *(if applicable)*
- [ ] `package.json` version bumped
- [ ] Added packages are compatible with installed Expo SDK (`npx expo install --check`)
- [ ] No new vulnerabilities introduced (`npm run audit`)

**Release** *(for `dev` → `staging` PRs)*
- [ ] Version bumped in `package.json`
- [ ] PR labelled correctly (`ota` if applicable)
